### PR TITLE
compatibility with the latest net-ssh

### DIFF
--- a/em-ssh.gemspec
+++ b/em-ssh.gemspec
@@ -18,7 +18,7 @@ require "rubygems"
   # If you have C extensions, uncomment this line
   # s.extensions = "ext/extconf.rb"
   s.add_dependency 'eventmachine', '~> 1.2'
-  s.add_dependency "net-ssh", '> 3.2'
+  s.add_dependency "net-ssh", '>= 5.0.2'
   # Not really necessary, but used in bin/em-ssh and bin/em-ssh-shell
   s.add_development_dependency 'ruby-termios', '~> 0.9'
   s.add_development_dependency "highline", '~> 1.6'

--- a/lib/em-ssh/connection.rb
+++ b/lib/em-ssh/connection.rb
@@ -345,11 +345,11 @@ module EventMachine
       def select_host_key_verifier(paranoid)
         case paranoid
         when true, nil then
-          Net::SSH::Verifiers::Lenient.new
+          Net::SSH::Verifiers::AcceptNewOrLocalTunnel.new
         when false then
-          Net::SSH::Verifiers::Null.new
+          Net::SSH::Verifiers::Never.new
         when :very then
-          Net::SSH::Verifiers::Strict.new
+          Net::SSH::Verifiers::AcceptNew.new
         else
           if paranoid.respond_to?(:verify)
             paranoid

--- a/lib/em-ssh/version.rb
+++ b/lib/em-ssh/version.rb
@@ -1,5 +1,5 @@
 module EventMachine
   class Ssh
-    VERSION='0.8.1'
+    VERSION='0.8.2'
   end
 end


### PR DESCRIPTION
Latest net-ssh introduced non backward compatible change: https://github.com/net-ssh/net-ssh/commit/29a8e97ae8d2eaf674a8694b775dc119985fa5e9 em-ssh needs to be updated because of that.